### PR TITLE
Moving to version 2.0

### DIFF
--- a/set_version.ps1
+++ b/set_version.ps1
@@ -2,7 +2,7 @@ param (
     [String]$BuildNumber = ""
 )
 
-$VersionMajor = "1"
-$VersionMinor = "3"
+$VersionMajor = "2"
+$VersionMinor = "0"
 
 Write-Host "##vso[task.setvariable variable=VersionString;]$VersionMajor.$VersionMinor.$BuildNumber"


### PR DESCRIPTION
Bumping version number to 2.0 for next release. This new version includes:

1. Emission of the Wall-Clock Time Responsibility metric in all views
2. /timetrace support

This version of vcperf emits traces that are not backward compatible with earlier versions and that require updating the perf_msvcbuildinsights.dll WPA add-in (i.e. recopying the file over to the WPA installation directory). 