### PR TITLE
Pipeline: Disabled CodeSign Validation on NuGet package

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -29,6 +29,7 @@ extends:
             packageParentPath: $(Build.ArtifactStagingDirectory)
             packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
             publishVstsFeed: $(feed-publish)
+            codeSignValidationEnabled: false
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
Disable the CodeSign Validation check on the binaries in the NuGet package output of the pipeline, since those binaries are intentionally unsigned due to being consumed internally