### PR TITLE
Encode RESULT_CODE into HRESULT to get additional error classification

### DIFF
--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -180,6 +180,14 @@ void PrintError(RESULT_CODE failureCode, bool admin = true)
     std::wcout << std::endl;
 }
 
+// Add a helper to convert RESULT_CODE ? a unique HRESULT:
+static HRESULT ResultCodeToHResult(RESULT_CODE rc)
+{
+    // FACILITY_ITF (4) is reserved for custom interface-specific errors
+    // The RESULT_CODE value goes into the low 16 bits
+    return MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, static_cast<WORD>(rc));
+}
+
 RESULT_CODE StopToWPA(const std::wstring& sessionName, const std::filesystem::path& outputFile, bool analyzeTemplates,
     TRACING_SESSION_STATISTICS& statistics)
 {
@@ -285,8 +293,8 @@ HRESULT DoStart(const std::wstring& sessionName, bool admin, bool cpuSampling, V
     {
         std::wcout << "Failed to start trace." << std::endl;
         PrintError(rc, admin);
-        
-        return E_FAIL;
+
+        return ResultCodeToHResult(rc);
     }
 
     std::wcout << L"Tracing session started successfully!" << std::endl;
@@ -315,7 +323,7 @@ HRESULT DoStop(const std::wstring& sessionName, const std::filesystem::path& out
         std::wcout << "Failed to stop trace." << std::endl;
         PrintError(rc);
 
-        return E_FAIL;
+        return ResultCodeToHResult(rc);
     }
 
     PrintPrivacyNotice(outputFile);
@@ -339,7 +347,7 @@ HRESULT DoStopNoAnalyze(const std::wstring& sessionName, const std::filesystem::
         std::wcout << "Failed to stop trace." << std::endl;
         PrintError(rc);
 
-        return E_FAIL;
+        return ResultCodeToHResult(rc);
     }
 
     PrintPrivacyNotice(outputFile);
@@ -365,7 +373,7 @@ HRESULT DoAnalyze(const std::filesystem::path& inputFile, const std::filesystem:
         std::wcout << "Failed to analyze trace." << std::endl;
         PrintError(rc);
 
-        return E_FAIL;
+        return ResultCodeToHResult(rc);
     }
 
     PrintPrivacyNotice(outputFile);
@@ -381,7 +389,7 @@ HRESULT DoGrantUserSessionControl()
     {
         std::wcout << "Failed to enable session control to user." << std::endl;
         PrintError(rc);
-        return E_FAIL;
+        return ResultCodeToHResult(rc);
     }
     std::wcout << L"Session control to user enabled successfully!" << std::endl;
 	return S_OK;

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -183,6 +183,11 @@ void PrintError(RESULT_CODE failureCode, bool admin = true)
 // Add a helper to convert RESULT_CODE to a unique HRESULT:
 static HRESULT ResultCodeToHResult(RESULT_CODE rc)
 {
+    if (rc == RESULT_CODE_SUCCESS)
+    {
+        return S_OK;
+    }
+
     // FACILITY_ITF (4) is reserved for custom interface-specific errors.
     // The RESULT_CODE value goes into the low 16 bits. Ensure that we do not
     // silently truncate values that do not fit in 16 bits.

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -183,9 +183,18 @@ void PrintError(RESULT_CODE failureCode, bool admin = true)
 // Add a helper to convert RESULT_CODE to a unique HRESULT:
 static HRESULT ResultCodeToHResult(RESULT_CODE rc)
 {
-    // FACILITY_ITF (4) is reserved for custom interface-specific errors
-    // The RESULT_CODE value goes into the low 16 bits
-    return MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, static_cast<WORD>(rc));
+    // FACILITY_ITF (4) is reserved for custom interface-specific errors.
+    // The RESULT_CODE value goes into the low 16 bits. Ensure that we do not
+    // silently truncate values that do not fit in 16 bits.
+    const unsigned long value = static_cast<unsigned long>(rc);
+
+    if (value > 0xFFFFUL)
+    {
+        // Fallback for out-of-range RESULT_CODE values; avoids truncation collisions.
+        return E_FAIL;
+    }
+
+    return MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, static_cast<WORD>(value));
 }
 
 RESULT_CODE StopToWPA(const std::wstring& sessionName, const std::filesystem::path& outputFile, bool analyzeTemplates,

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -180,7 +180,7 @@ void PrintError(RESULT_CODE failureCode, bool admin = true)
     std::wcout << std::endl;
 }
 
-// Add a helper to convert RESULT_CODE ? a unique HRESULT:
+// Add a helper to convert RESULT_CODE to a unique HRESULT:
 static HRESULT ResultCodeToHResult(RESULT_CODE rc)
 {
     // FACILITY_ITF (4) is reserved for custom interface-specific errors

--- a/src/Commands.h
+++ b/src/Commands.h
@@ -3,6 +3,8 @@
 #include <filesystem>
 #include <string>
 
+#include "VcperfBuildInsights.h"
+
 namespace vcperf
 {
 

--- a/src/Commands.h
+++ b/src/Commands.h
@@ -3,8 +3,6 @@
 #include <filesystem>
 #include <string>
 
-#include "VcperfBuildInsights.h"
-
 namespace vcperf
 {
 


### PR DESCRIPTION
•	Added static HRESULT ResultCodeToHResult(RESULT_CODE rc) helper that maps RESULT_CODE → HRESULT.
•	Replaced return E_FAIL with return ResultCodeToHResult(rc)

New Hex values based on RESULT_CODE:
| RESULT_CODE | Hex | Description |
|---|---|---|
| SUCCESS | 0x00000000 (S_OK) | Success |
| FAILURE_ANALYSIS_ERROR | 0x80040001 | Callback returned analysis failure |
| FAILURE_CANCELLED | 0x80040002 | Callback returned cancel |
| FAILURE_INVALID_INPUT_LOG_FILE | 0x80040003 | Invalid input ETW trace |
| FAILURE_INVALID_OUTPUT_LOG_FILE | 0x80040004 | Invalid output ETW trace |
| FAILURE_MISSING_ANALYSIS_CALLBACK | 0x80040005 | ANALYSIS_CALLBACKS not initialized |
| FAILURE_MISSING_RELOG_CALLBACK | 0x80040006 | RELOG_CALLBACKS not initialized |
| FAILURE_OPEN_INPUT_TRACE | 0x80040007 | Failed to open input ETW trace |
| FAILURE_PROCESS_TRACE | 0x80040008 | Error processing input ETW trace |
| FAILURE_START_RELOGGER | 0x80040009 | Failed to start relogging session |
| FAILURE_DROPPED_EVENTS | 0x8004000A | Input trace missing important events |
| FAILURE_UNSUPPORTED_OS | 0x8004000B | Unsupported Windows version |
| FAILURE_UNEXPECTED_TRACE | 0x8004000C | Unexpected/incompatible trace encountered |
| FAILURE_INVALID_TRACING_SESSION_NAME | 0x8004000D | Invalid session name |
| FAILURE_INSUFFICIENT_PRIVILEGES | 0x8004000E | Requires admin privileges |
| FAILURE_GENERATE_GUID | 0x8004000F | GUID generation error |
| FAILURE_OBTAINING_TEMP_DIRECTORY | 0x80040010 | Temp directory lookup error |
| FAILURE_CREATE_TEMPORARY_DIRECTORY | 0x80040011 | Temp directory creation error |
| FAILURE_START_SYSTEM_TRACE | 0x80040012 | Failed to start system trace |
| FAILURE_START_MSVC_TRACE | 0x80040013 | Failed to start MSVC trace |
| FAILURE_STOP_MSVC_TRACE | 0x80040014 | Failed to stop MSVC trace |
| FAILURE_STOP_SYSTEM_TRACE | 0x80040015 | Failed to stop system trace |
| FAILURE_SESSION_DIRECTORY_RESOLUTION | 0x80040016 | Session temp dir not found |
| FAILURE_MSVC_TRACE_FILE_NOT_FOUND | 0x80040017 | MSVC trace file not found |
| FAILURE_MERGE_TRACES | 0x80040018 | Kernel Trace Control merge error |
| FAILURE_UNKNOWN_ERROR | 0x80040019 | Unknown error |
| FAILURE_NO_CONTEXT_INFO_AVAILABLE | 0x8004001A | MSVC toolset doesn't support /noadmin (needs toolset ≥16.11) |
| FAILURE_SET_PROVIDER_EVENT_ACCESS_CONTROL | 0x8004001B | Failed to set access control on ETW providers |
| FAILURE_UNSUPPORTED_SECURITY_DESCRIPTOR | 0x8004001C | Unsupported security descriptor |
| STATUS_CONTROL_C_EXIT | 0xC000013A | Process terminated by Ctrl+C or console close |